### PR TITLE
1: Added TZ export to the make process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ STATIC_ARCHIVE=$(BUILD_DIR)/static.tgz
 INSTALL_TARGETS=$(addsuffix .install, $(LIBS))
 APP_JARS=$(addprefix $(BUILD_DIR)/, $(addsuffix .jar, $(APPS)))
 
+# FIXME: this will allow the date string to work with
+# different timezones.
+export TZ:="Europe/London"
+
 all: $(BUILD_DIR) $(APP_JARS) $(STATIC_ARCHIVE)
 
 libs: $(INSTALL_TARGETS)

--- a/front-end/test/front_end/unit/data.clj
+++ b/front-end/test/front_end/unit/data.clj
@@ -4,7 +4,7 @@
             [front-end.data :as data]))
 
 (def good-news-response
-  {:body (json/write-str {:entries [{:published-date "2015-01-01T00:00:00.000+0000"
+  {:body (json/write-str {:entries [{:published-date "2017-01-01T00:00:00.000+0000"
                                      :title "Title 1"}]})
    :status 200})
 
@@ -18,7 +18,7 @@
        (fact "handle-news-response catches errors"
              (data/handle-news-response (future bad-response)) => (throws Exception "Error getting response: status 500 returned"))
        (fact "handle-news-response correctly processes entries"
-             (let [d (.parse (java.text.SimpleDateFormat. "yyyy-MM-dd") "2015-01-01T00:00:00.000+0000")]
+             (let [d (.parse (java.text.SimpleDateFormat. "yyyy-MM-dd") "2017-01-01T00:00:00.000+0000")]
                (data/handle-news-response (future good-news-response))
                => [{"published-date" d
                     "title"          "Title 1"

--- a/newsfeed/test/newsfeed/unit/api.clj
+++ b/newsfeed/test/newsfeed/unit/api.clj
@@ -27,8 +27,8 @@
 
 (facts "about 'formatting'"
        (fact "given various values will format correctly"
-             (api/format-key-value :published-date (.parse (java.text.SimpleDateFormat. "yyyy-MM-dd") "2016-01-01"))
-             => "2016-01-01T00:00:00.000+0000"
+             (api/format-key-value :published-date (.parse (java.text.SimpleDateFormat. "yyyy-MM-dd") "2017-01-01"))
+             => "2017-01-01T00:00:00.000+0000"
              (api/format-key-value :title "Title")
              => "Title"))
 


### PR DESCRIPTION
Added timezone export to the make process
so the hardcoded test strings will work
across locations. Also, updated dates.