### PR TITLE
Make the apps more resilient

### DIFF
--- a/front-end/src/front_end/data.clj
+++ b/front-end/src/front_end/data.clj
@@ -1,13 +1,18 @@
 (ns front-end.data
   (:require [common-utils.core :as utils]
             [clojure.data.json :as json]
+            [clojure.string :as st]
             [org.httpkit.client :as http]))
 
+(defn- remove-trailing-slashes
+  [s]
+  (st/replace s #"/+$" ""))
+
 (def quote-service-url
-  (utils/config "QUOTE_SERVICE_URL" "http://localhost:8080"))
+  (remove-trailing-slashes (utils/config "QUOTE_SERVICE_URL" "http://localhost:8080")))
 
 (def newsfeed-service-url
-  (utils/config "NEWSFEED_SERVICE_URL" "http://localhost:8080"))
+  (remove-trailing-slashes (utils/config "NEWSFEED_SERVICE_URL" "http://localhost:8080")))
 
 (def newsfeed-token
   (utils/config "NEWSFEED_SERVICE_TOKEN" ""))

--- a/quotes/src/quotes/routes.clj
+++ b/quotes/src/quotes/routes.clj
@@ -3,6 +3,7 @@
   (:use [quotes.api :only [api-routes]])
   (:require [compojure.core :refer :all]
             [compojure.route :as route]
+            [clojure.data.json :as json]
             [common-utils.core :as utils]
             [common-utils.middleware :refer [correlation-id-middleware]]
             [clojure.tools.logging :as log]
@@ -11,7 +12,8 @@
 (defroutes app-routes
   (GET "/ping" [] {:status 200})
   (context "/api" []
-           (api-routes)))
+           (api-routes))
+  (route/not-found (json/write-str {:error "Not found"})))
 
 (def app
   (-> app-routes


### PR DESCRIPTION
* Add a 404 route for the quotes service so if a route doesn't match then you actually get a useful error messsage
* Trim trailing slashes from values provided for the service URLs to the front-end service as they break the app